### PR TITLE
Check for System Compatibility before doing anything else

### DIFF
--- a/Dell Command Update/Dell Command Update Automation Toolkit.ps1
+++ b/Dell Command Update/Dell Command Update Automation Toolkit.ps1
@@ -161,7 +161,7 @@ function Get-DeviceCompatibility {
 
     # Check model and exit if incompatible (Update as compatible models are discovered)
     $model = (Get-WmiObject Win32_ComputerSystem).Model
-    if ($model -notmatch "Optiplex|Precision|Latitude") {
+    if ($model -notmatch "Optiplex|Precision|Latitude|XPS") {
         Write-Output "Non-compatible model detected: $model. Exiting."
         Ninja-Property-Set $firmwareBiosUpdateField "Non-compatible model: $model"
         Ninja-Property-Set $biosFirmwareUpdatesField "Non-compatible model: $model - $(Get-Date)"

--- a/Dell Command Update/Dell Command Update Automation Toolkit.ps1
+++ b/Dell Command Update/Dell Command Update Automation Toolkit.ps1
@@ -170,7 +170,6 @@ function Get-DeviceCompatibility {
 }
 
 function Invoke-PreinstallChecks {
-    Get-DeviceCompatibility
     $IncompatibleApps = Get-ChildItem -Path $RegPaths | Get-ItemProperty | Where-Object { $_.DisplayName -like 'Dell Update*' }
     foreach ($App in $IncompatibleApps) {
         Write-Output "Attempting to remove program: [$($App.DisplayName)]"
@@ -329,25 +328,32 @@ function Invoke-DCUBiosFirmwareScan {
 
 switch ($env:pleaseSelectAnOptionToRun) {
     "Install" {
+        Get-DeviceCompatibility
         Invoke-PreinstallChecks
         Install-DCU
     }
     "Remove Incompatible Versions" {
+        Get-DeviceCompatibility
         Invoke-PreinstallChecks
     }
     "Run Scan" {
+        Get-DeviceCompatibility
         Invoke-DCUScan
     }
     "Run BIOS and Firmware Scan" {
+        Get-DeviceCompatibility
         Invoke-DCUBiosFirmwareScan
     }
     "Run Scan And Install All" {
+        Get-DeviceCompatibility
         Invoke-DCUandInstall -UpdateType 'all'
     }
     "Run Scan And Install Excluding BIOS and Firmware" {
+        Get-DeviceCompatibility
         Invoke-DCUandInstall -UpdateType 'driver,application'
     }
     "Run Scan And Install BIOS and Firmware ONLY" {
+        Get-DeviceCompatibility
         Invoke-DCUandInstall -UpdateType 'firmware,bios'
     }
     default {


### PR DESCRIPTION
Since DCU isn't compatible with servers or non-business models, check for and exit if one of those are detected. Also exit if runs on a non-Dell by mistake.